### PR TITLE
AG : Ajoute dynamiquement les pays votants, et notifie le vote sur Discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,4 @@ DISCORD_WEBHOOKURL_DEBUG=https://discord.com/api/webhooks/*
 DISCORD_WEBHOOKURL_MONDEGC=https://discord.com/api/webhooks/*
 DISCORD_WEBHOOKURL_OCGC=https://discord.com/api/webhooks/*
 DISCORD_WEBHOOKURL_PRIVATE=https://discord.com/api/webhooks/*
+DISCORD_ROLE_PLAYERS_ID=

--- a/app/Jobs/Discord/NotifyCreatedProposal.php
+++ b/app/Jobs/Discord/NotifyCreatedProposal.php
@@ -21,11 +21,6 @@ class NotifyCreatedProposal implements ShouldQueue, NotifiesDiscord
 
     private string $webhookName = 'ocgc';
 
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
     public function __construct(OcgcProposal $proposal)
     {
         $this->proposal = $proposal;

--- a/app/Jobs/Discord/NotifyFinishedProposal.php
+++ b/app/Jobs/Discord/NotifyFinishedProposal.php
@@ -21,11 +21,6 @@ class NotifyFinishedProposal implements ShouldQueue, NotifiesDiscord
 
     private string $webhookName = 'ocgc';
 
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
     public function __construct(OcgcProposal $proposal)
     {
         $this->proposal = $proposal;

--- a/app/Jobs/Discord/NotifyVotingProposal.php
+++ b/app/Jobs/Discord/NotifyVotingProposal.php
@@ -21,11 +21,6 @@ class NotifyVotingProposal implements ShouldQueue, NotifiesDiscord
 
     private string $webhookName = 'ocgc';
 
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
     public function __construct(OcgcProposal $proposal)
     {
         $this->proposal = $proposal;
@@ -43,9 +38,15 @@ class NotifyVotingProposal implements ShouldQueue, NotifiesDiscord
 
     public function generatePayload(): array
     {
+        $content = "**VOTE EN COURS !**\r\n"
+            . "Une proposition est en cours de vote à l'Assemblée générale !";
+
+        if(! empty($roleId = config('discord.role.players'))) {
+            $content .= "\r\n<@&$roleId>";
+        }
+
         return [
-            'content' => "**VOTE EN COURS !**\r\n"
-                . "Une proposition est en cours de vote à l'Assemblée générale !",
+            'content' => $content,
             'embeds' => [
                 [
                     'title' => trim(Str::limit($this->proposal->question, 120)),

--- a/app/Models/OcgcProposal.php
+++ b/app/Models/OcgcProposal.php
@@ -119,6 +119,9 @@ class OcgcProposal extends Model
         'RP'  => "Résolution",
     ];
 
+    /**
+     * @inheritDoc
+     */
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
@@ -128,6 +131,7 @@ class OcgcProposal extends Model
 
     /**
      * Pays à l'origine de la proposition.
+     *
      * @return BelongsTo
      */
     public function pays(): BelongsTo
@@ -160,6 +164,7 @@ class OcgcProposal extends Model
 
     /**
      * Nombre total de réponses possibles pour une proposition.
+     *
      * @return int
      */
     public function getMaxResponses(): int
@@ -170,6 +175,7 @@ class OcgcProposal extends Model
 
     /**
      * Donne la collection des réponses à une proposition, y compris le vote blanc.
+     *
      * @return Collection
      */
     public function responses(): Collection
@@ -189,6 +195,7 @@ class OcgcProposal extends Model
 
     /**
      * Renvoie le choix à l'issue du vote.
+     *
      * @return Collection Collection de réponses.
      */
     public function results(): Collection
@@ -200,6 +207,7 @@ class OcgcProposal extends Model
 
     /**
      * Donne le détail du type de la proposition.
+     *
      * @return string "Sondage" ou "Résolution", en fonction du type de la proposition.
      */
     public function typeDetail(): string
@@ -209,6 +217,7 @@ class OcgcProposal extends Model
 
     /**
      * Renvoie l'identifiant complet d'une proposition (e.g. "Résolution 21-072").
+     *
      * @return string
      */
     public function fullIdentifier(): string

--- a/config/discord.php
+++ b/config/discord.php
@@ -33,4 +33,19 @@ return [
         'private' => env('DISCORD_WEBHOOKURL_PRIVATE'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Identifiants.
+    |--------------------------------------------------------------------------
+    |
+    | Ici, il est possible de définir des identifiants spécifiques
+    | (utilisateurs, rôles, salons, etc.)
+    |
+    */
+
+    'role' => [
+        // Spécifie l'identifiant du rôle "Dirigeant Monde GC", à des fins de mentions.
+        'players' => env('DISCORD_ROLE_PLAYERS_ID'),
+    ],
+
 ];

--- a/config/gameplay.php
+++ b/config/gameplay.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Inactivité
+    |--------------------------------------------------------------------------
+    |
+    | Gère la durée d'inactivité à partir duquel un pays est considéré comme
+    | inactif. Cela a des effets au niveau de la génération des statistiques ou
+    | la participation aux votes de l'Assemblée générale.
+    |
+    */
+
+    'country_inactivity_months' => 4,
+
+];

--- a/legacy/dashboard.php
+++ b/legacy/dashboard.php
@@ -3,10 +3,14 @@
 //Connexion et deconnexion
 include('php/log.php');
 
-if(isset($_SESSION['login_user'])) {
-    $thisUser = new GenCity\Monde\User($_SESSION['user_ID']);
-    $listePays = $thisUser->getCountries();
+$listePays = [];
+if(!isset($_SESSION['login_user'])) {
+    header(sprintf("Location: %s", urlFromLegacy(url('connexion.php'))));
+    exit;
 }
+
+$thisUser = new GenCity\Monde\User($_SESSION['user_ID']);
+$listePays = $thisUser->getCountries();
 
 $listeInstituts = \GenCity\Monde\Institut\Institut::getAll();
 
@@ -136,9 +140,9 @@ Eventy::action('display.beforeHeadClosingTag')
         <?php foreach($listeInstituts as $thisInstitut): ?>
             <div class="span2 thumbnail">
 
-                <img src="<?= __s($thisInstitut->get('ch_ins_logo')) ?>" style="max-height: 60px;"
-                     alt="Logo <?= __s($thisInstitut->get('ch_ins_nom')) ?>">
-                <h4><?= __s($thisInstitut->get('ch_ins_nom')) ?></h4>
+                <img src="<?= e($thisInstitut->get('ch_ins_logo')) ?>" style="max-height: 60px;"
+                     alt="Logo <?= e($thisInstitut->get('ch_ins_nom')) ?>">
+                <h4><?= e($thisInstitut->get('ch_ins_nom')) ?></h4>
 
                 <div class="btn-group">
                 <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -183,8 +187,8 @@ Eventy::action('display.beforeHeadClosingTag')
                                     <i class="icon-file"></i> Publier un communiqué</a></li>
                             <li class="dropdown-li-force">
                                 <a tabindex="0" href="<?= route('infrastructure.select-group',
-                                    ['infrastructurable_type' => 'pays',
-                                     'infrastructurable_id' => $pays['ch_pay_id']]) ?>">
+                                    ['infrastructurableType' => 'pays',
+                                     'infrastructurableId' => $pays['ch_pay_id']]) ?>">
                                     <i class="icon-home"></i> Ajouter une infrastructure</a></li>
                         </ul>
                     </div>

--- a/legacy/php/GenCity/Monde/Pays.php
+++ b/legacy/php/GenCity/Monde/Pays.php
@@ -100,12 +100,13 @@ class Pays extends BaseModel {
 
     public function isActive() {
 
+        $inactivityMonths = config('gameplay.country_inactivity_months');
         $mysql_query = mysql_query(sprintf(
         'SELECT ID_pays AS ch_pay_id, MAX(ch_use_last_log) FROM users_pays
               JOIN users ON ch_use_id = ID_user
               WHERE ID_pays = %s
               GROUP BY ch_pay_id
-              HAVING MAX(ch_use_last_log) > DATE_SUB(NOW(), INTERVAL 4 MONTH)',
+              HAVING MAX(ch_use_last_log) > DATE_SUB(NOW(), INTERVAL ' . $inactivityMonths . ' MONTH)',
             escape_sql($this->get('ch_pay_id'))
             ));
         $results = mysql_fetch_assoc($mysql_query);

--- a/legacy/php/GenCity/Monde/PaysList.php
+++ b/legacy/php/GenCity/Monde/PaysList.php
@@ -32,14 +32,14 @@ class PaysList {
     }
 
     public function getActive() {
-
+        $inactivityMonths = config('gameplay.country_inactivity_months');
         $query = '
           SELECT ID_pays AS ch_pay_id, MAX(ch_use_last_log) FROM users_pays
           JOIN users ON ch_use_id = ID_user
           JOIN pays ON ID_pays = ch_pay_id
           WHERE ch_pay_publication != 2
           GROUP BY ch_pay_id
-          HAVING MAX(ch_use_last_log) > DATE_SUB(NOW(), INTERVAL 4 MONTH)';
+          HAVING MAX(ch_use_last_log) > DATE_SUB(NOW(), INTERVAL ' . $inactivityMonths . ' MONTH)';
         return $this->setListFromQuery($query);
 
     }

--- a/legacy/php/GenCity/Monde/User/UserList.php
+++ b/legacy/php/GenCity/Monde/User/UserList.php
@@ -33,8 +33,9 @@ class UserList {
 
     public function getActive() {
 
+        $inactivityMonths = config('gameplay.country_inactivity_months');
         $query = 'SELECT ch_use_id FROM users
-                  WHERE ch_use_last_log > DATE_SUB(NOW(), INTERVAL 4 MONTH)';
+                  WHERE ch_use_last_log > DATE_SUB(NOW(), INTERVAL ' . $inactivityMonths . ' MONTH)';
         return $this->setListFromQuery($query, true);
 
     }

--- a/legacy/php/GenCity/Proposal/ProposalList.php
+++ b/legacy/php/GenCity/Proposal/ProposalList.php
@@ -64,6 +64,13 @@ class ProposalList {
 
     }
 
+    public function getUnfinished() {
+
+        $query = 'SELECT id FROM ocgc_proposals WHERE is_valid = 2 AND debate_end > NOW()';
+        return $this->setListFromQuery($query);
+
+    }
+
     public function getFinished($limit = 8, $offset = 0) {
 
         $query = 'SELECT id FROM ocgc_proposals

--- a/legacy/php/GenCity/Proposal/ProposalList.php
+++ b/legacy/php/GenCity/Proposal/ProposalList.php
@@ -8,10 +8,6 @@ class ProposalList {
 
     private $list = array();
 
-    public function __construct() {
-
-    }
-
     private function setListFromQuery($query) {
 
         $this->list = array();

--- a/legacy/php/GenCity/Proposal/ProposalRoutine.php
+++ b/legacy/php/GenCity/Proposal/ProposalRoutine.php
@@ -9,21 +9,23 @@ class ProposalRoutine
 {
     private ProposalList $proposalList;
 
-    public function __construct()
+    /**
+     * @param ProposalList $proposalList
+     */
+    public function __construct(ProposalList $proposalList)
     {
-        $this->proposalList = new ProposalList;
-
-        $this->runRoutine();
+        $this->proposalList = $proposalList;
     }
 
     /**
      * Permet de limiter l'exécution d'une routine, en fonction de la génération d'un nombre aléatoire.
      * Sur les environnements de développement, cette méthode est inopérante et renvoie toujours <code>false</code>.
+     *
      * @param int $probability Probabilté d'exécution (e.g. mettre "4" pour 1 fois sur 4).
      * @return bool Si cette méthode renvoie <code>true</code>, la routine ne devrait pas être exécutée.
      *              Dans le cas contraire, il faudra l'exécuter.
      */
-    private function shouldThrottle(int $probability = 4): bool
+    private function shouldThrottle(int $probability = 3): bool
     {
         // Pour des raisons de performance, exécuter une fois sur quatre en moyenne.
         return (app()->environment() === 'production' && rand(1, $probability) !== 1);
@@ -38,13 +40,16 @@ class ProposalRoutine
             $this->checkValidPending();
             $this->sendPendingNotifications();
             $this->sendFinishedNotifications();
-        } catch(\Exception $ignored) { }
+        } catch(\Exception $ex) {
+            if(app()->environment() !== 'production') {
+                throw $ex;
+            }
+        }
     }
 
     /**
-     * Cette fonction met à jour toutes les propositions en attente de validation par l'OCGC
-     * et créés il y a plus d'une semaine et les définit comme validés par l'OCGC (principe
-     * d'accord sans réponse).
+     * Met à jour toutes les propositions en attente de validation par l'OCGC et crées il y a plus
+     * d'une semaine et les définit comme validés par l'OCGC (principe d'accord sans réponse).
      */
     private function checkValidPending(): void
     {

--- a/legacy/php/GenCity/Proposal/ProposalRoutine.php
+++ b/legacy/php/GenCity/Proposal/ProposalRoutine.php
@@ -2,6 +2,7 @@
 
 namespace GenCity\Proposal;
 
+use Illuminate\Support\Facades\DB;
 use Roxayl\MondeGC\Jobs\Discord;
 use Roxayl\MondeGC\Models\OcgcProposal;
 use Roxayl\MondeGC\Models\Pays;
@@ -37,12 +38,15 @@ class ProposalRoutine
      */
     public function runRoutine(): void
     {
+        DB::beginTransaction();
         try {
             $this->checkValidPending();
             $this->updateVotingCountries();
             $this->sendPendingNotifications();
             $this->sendFinishedNotifications();
+            DB::commit();
         } catch(\Exception $ex) {
+            DB::rollBack();
             if(app()->environment() !== 'production') {
                 throw $ex;
             }

--- a/legacy/php/log.php
+++ b/legacy/php/log.php
@@ -312,4 +312,4 @@ do {
 
 
 /* Vérification des propositions */
-$proposalRoutine = new \GenCity\Proposal\ProposalRoutine();
+(new \GenCity\Proposal\ProposalRoutine(new \GenCity\Proposal\ProposalList()))->runRoutine();

--- a/legacy/php/navbar.php
+++ b/legacy/php/navbar.php
@@ -23,9 +23,6 @@ if(isset($_SESSION['userObject'])) {
     $nav_userPays = $_SESSION['userObject']->getCountries();
 }
 
-if(!isset($loginFormAction))
-    $loginFormAction = '';
-
 /** Notifications navbar Assemblée générale */
 $navbar_proposalList = new \GenCity\Proposal\ProposalList();
 $navbar_pendingVotes = $navbar_proposalList->getPendingVotes();
@@ -173,11 +170,7 @@ $navbar_organisationList = \Roxayl\MondeGC\Models\Organisation::allOrdered()->ge
               <a href="<?= DEF_URI_PATH ?>dashboard.php" title="informations pratiques"><i class="icon icon-evenement"></i></a>
             </center>
             <a href="<?= DEF_URI_PATH ?>dashboard.php" title="informations pratiques">Tableau de bord</a>
-          <ul class="dropdown-menu">            
-              <li><a href="https://www.forum-gc.com">Le forum</a></li>
-              <li><a href="http://vasel.yt/wiki/index.php?title=Accueil">Le Wiki</a></li>
-        <li><a href="https://squirrel.roxayl.fr/">Squirrel</a></li>
-            </ul></li>
+          </li>
         <?php endif; ?>
 
           <li class="dropdown <?php if ($carte || $menupays) { echo('active');}  ?>">


### PR DESCRIPTION
Cette pull request ajoute de nouveaux éléments à l'AG :

- Les pays votants à l'AG correspondent aux pays actifs déterminés au moment de la création de la proposition. Cela était problématique car, si un pays inactif redevenait actif après la création de la proposition (par exemple, au moment du vote), il n'était pas autorisé à voter. Désormais, les votants d'une proposition sont mis à jour automatiquement en fonction de la liste des pays actifs, jusqu'à la fin de la période de vote.
- Les membres Discord ayant le rôle "Dirigeant Monde GC" sont notifiés lors du début de la phase de vote d'une proposition.
