### PR TITLE
Notifie releases sur Discord

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  update-release:
+  bump-release:
     name: "⬆️ Bump production release"
     runs-on: ubuntu-20.04
 
@@ -22,3 +22,17 @@ jobs:
             cd "${{ vars.PROD_FULL_DIR }}"
             VERSION_NUMBER="${{ github.event.release.name }}"
             find ./.env -type f -exec sed -i '' -e "/^APP_VERSION=/s/=.*/=\'$VERSION_NUMBER\'/" {} \;
+
+  notify-release:
+    name: "📣 Notify release"
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Notify on Discord
+        uses: SethCohen/github-releases-to-discord@v1.13.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
Lors de la création d'une nouvelle version du site (release), une notification est postée via un webhook sur Discord, contenant les notes de version autogénérés par Git.

On utilise cette action GitHub pour le faire : https://github.com/SethCohen/github-releases-to-discord

(à voir s'il en existe des mieux...?)