### PR TITLE
Corrige la génération des ressources et améliore le cache des ressources

### DIFF
--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -349,7 +349,7 @@ class Organisation extends Model implements Searchable, Infrastructurable, Resou
             $paysMembers = $this->members;
 
             foreach($paysMembers as $members) {
-                $thisPaysResources = $members->pays->resources(false);
+                $thisPaysResources = $members->pays->withoutOrganisationResources();
                 foreach(Resource::cases() as $resource) {
                     $sumResources[$resource->value] += $thisPaysResources[$resource->value];
                 }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -345,11 +345,11 @@ class Organisation extends Model implements Searchable, Infrastructurable, Resou
 
         // Les alliances bénéficient les ressources de leurs pays ; on les calcule
         // le cas échéant.
-        if($this->type === self::TYPE_ALLIANCE) {
+        if($this->membersGenerateResources()) {
             $paysMembers = $this->members;
 
             foreach($paysMembers as $members) {
-                $thisPaysResources = $members->pays->withoutOrganisationResources();
+                $thisPaysResources = $members->pays->withoutAllianceResources();
                 foreach(Resource::cases() as $resource) {
                     $sumResources[$resource->value] += $thisPaysResources[$resource->value];
                 }
@@ -357,6 +357,16 @@ class Organisation extends Model implements Searchable, Infrastructurable, Resou
         }
 
         return $sumResources;
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    public function perCountryResources(): array
+    {
+        $memberCount = $this->members->count();
+
+        return array_map(fn(float $value) => (int) ($value / $memberCount), $this->organisationResources());
     }
 
     /**

--- a/app/Models/Traits/Resourceable.php
+++ b/app/Models/Traits/Resourceable.php
@@ -11,10 +11,10 @@ trait Resourceable
     /**
      * Donne le nom de la clé pour récupérer ou stocker les ressources générées dans le cache.
      *
-     * @param null $parameters
+     * @param mixed $parameters
      * @return string
      */
-    public function resourceCacheKey($parameters = null): string
+    public function resourceCacheKey(mixed $parameters = null): string
     {
         $stringParameters = null;
         if($parameters !== null) {

--- a/app/Models/Traits/Resourceable.php
+++ b/app/Models/Traits/Resourceable.php
@@ -2,6 +2,8 @@
 
 namespace Roxayl\MondeGC\Models\Traits;
 
+use Illuminate\Support\Str;
+
 trait Resourceable
 {
     use SimpleResourceable, GeneratesResourceHistory;
@@ -16,7 +18,7 @@ trait Resourceable
     {
         $stringParameters = null;
         if($parameters !== null) {
-            $stringParameters = json_encode($parameters);
+            $stringParameters = Str::slug(json_encode($parameters), '-', 'en', [':' => '_']);
         }
 
         $key = str_replace('\\', '.', $this::class) . '.' . $this->getKey();

--- a/app/Services/EconomyService.php
+++ b/app/Services/EconomyService.php
@@ -5,8 +5,8 @@ namespace Roxayl\MondeGC\Services;
 use Illuminate\Database\Eloquent\Collection;
 use Roxayl\MondeGC\Models\Enums\Resource;
 use Roxayl\MondeGC\Models\Pays;
-use Roxayl\MondeGC\Models\Traits\Influencable;
-use Roxayl\MondeGC\Models\Traits\Resourceable;
+use Roxayl\MondeGC\Models\Contracts\Influencable;
+use Roxayl\MondeGC\Models\Contracts\Resourceable;
 
 class EconomyService
 {
@@ -60,7 +60,7 @@ class EconomyService
      * @return float[] Un tableau de ressources contenant la somme  les ressources générées un
      *                 ensemble d'influençables.
      */
-    public static function sumGeneratedResourcesFromInfluencables(array|\ArrayAccess $influencables): array
+    public static function sumGeneratedResourcesFromInfluencables(iterable $influencables): array
     {
         $sumResources = EconomyService::resourcesPrefilled();
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -91,4 +91,18 @@ return [
 
     'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Paramètres de cache
+    |--------------------------------------------------------------------------
+    |
+    | Il est possible de spécifier certains paramètres comme la borne de durée
+    | de mise en cache de certaines données.
+    |
+    */
+
+    'ttl_lower_bound' => 12,
+
+    'ttl_higher_bound' => 30,
+
 ];

--- a/resources/views/organisation/components/economie.blade.php
+++ b/resources/views/organisation/components/economie.blade.php
@@ -1,15 +1,22 @@
 
 @inject('helperService', 'Roxayl\MondeGC\Services\HelperService')
 
+@section('scripts')
+    @parent
+
+    @if($organisation->membersGenerateResources())
+    <script type="text/javascript">
+        (function($) {
+            let $resourceTooltip = $('#org-country-resource-tooltip');
+            if($resourceTooltip.length) {
+                $resourceTooltip.tooltip();
+            }
+        })(jQuery);
+    </script>
+    @endif
+@endsection
+
 @if($organisation->hasEconomy())
-
-    @section('scripts')
-        @parent
-
-        <script type="text/javascript">
-            $('#org-country-resource-tooltip').tooltip();
-        </script>
-    @endsection
 
     @can('manageInfrastructure', $organisation)
     <div class="cta-title pull-right-cta">

--- a/resources/views/organisation/components/economie.blade.php
+++ b/resources/views/organisation/components/economie.blade.php
@@ -3,6 +3,14 @@
 
 @if($organisation->hasEconomy())
 
+    @section('scripts')
+        @parent
+
+        <script type="text/javascript">
+            $('#org-country-resource-tooltip').tooltip();
+        </script>
+    @endsection
+
     @can('manageInfrastructure', $organisation)
     <div class="cta-title pull-right-cta">
         <a href="{{ route('organisation.edit',
@@ -75,14 +83,29 @@
                 <small>Ressources octroyées à chaque pays membre :</small>
                 {!! $helperService::renderLegacyElement(
                     'temperance/resources_small', [
-                        'resources' => array_map(
-                            fn($val) => ($val / $organisation->members->count()),
-                            $organisation->infrastructureResources())
+                        'resources' => $organisation->perCountryResources()
                     ]) !!}
             </div>
 
             @if($organisation->membersGenerateResources())
-                <h4>Ressources générées par les pays membres</h4>
+                <h4>
+                    Ressources générées par les pays membres
+                    <small>
+                        <i class="icon-info-sign" rel="tooltip" id="org-country-resource-tooltip"
+                           data-original-title="Ces données totalisent les ressources générées directement par les pays
+                            sans l'influence générée par les organisations dont elles sont membres. Elles sont
+                            additionnées pour obtenir les ressources de l'organisation."
+                        ></i>
+                    </small>
+                </h4>
+
+                <div style="margin-bottom: 7px;">
+                    <small>Total pays membres :</small>
+                    {!! $helperService::renderLegacyElement(
+                        'temperance/resources_small', [
+                            'resources' => $organisation->paysResources()
+                        ]) !!}
+                </div>
 
                 @foreach($organisation->members as $thisMember)
                     @php $thisPays = $thisMember->pays; @endphp
@@ -94,7 +117,7 @@
                             {{ $thisPays->ch_pay_nom }}</a>
                         {!! $helperService::renderLegacyElement(
                             'temperance/resources_small', [
-                                'resources' => $thisPays->resources(false)
+                                'resources' => $thisPays->withoutAllianceResources()
                             ]) !!}
                     </div>
                 @endforeach


### PR DESCRIPTION
Cette pull request corrige des bugs dans le calcul des ressources :

- lors du calcul des ressources de pays, les ressources générées par le roleplay des organisations dont le pays est membre n'était pas pris en compte.
- le calcul des ressources des organisations était également erroné

Le total des ressources des alliances issues des pays est également affiché sur le détail des ressources de ces organisations.

Par ailleurs, elle améliore la gestion du cache des ressources, en générant une durée aléatoire au cache. Cela évite le problème où tous les caches de ressources étaient susceptibles d'expirer en même temps, ce qui provoque la génération de l'ensemble des ressources en accédant à certaines pages, comme la page Economie qui calcule les ressources de tous les pays actifs et provoque des lenteurs.
