### PR TITLE
Fix type colonne inadapté pr ID pays

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,10 +25,11 @@ services:
     volumes:
       - ./docker/mysql/data:/var/lib/mysql
       - ./docker/mysql/entrypoint:/docker-entrypoint-initdb.d
-    command: [mysqld,
-        --default-authentication-plugin=mysql_native_password,
-        --character-set-server=utf8mb4,
-        --collation-server=utf8mb4_unicode_ci]
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --sql-mode=IGNORE_SPACE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
     environment:
       MYSQL_ROOT_PASSWORD: root
 

--- a/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
+++ b/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class FixTinyintToInt extends Migration
 {
     /**
      * Run the migrations.
@@ -13,6 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
+        DB::statement('UPDATE `histoire` SET ch_his_date_fait = "0001-01-01 00:00:00"'
+            . ' WHERE ch_his_date_fait IS NULL OR ch_his_date_fait = "0000-00-00 00:00:00"');
+        DB::statement('UPDATE `histoire` SET ch_his_date_fait2 = NULL'
+            . ' WHERE ch_his_date_fait2 = "0000-00-00 00:00:00"');
+
         Schema::table('histoire', function (Blueprint $table) {
             $table->integer('ch_his_paysID')->change();
         });
@@ -30,11 +35,11 @@ return new class extends Migration
     public function down()
     {
         Schema::table('histoire', function (Blueprint $table) {
-            $table->tinyInteger('ch_his_paysID')->change();
+            $table->smallInteger('ch_his_paysID')->change();
         });
 
         Schema::table('patrimoine', function (Blueprint $table) {
-            $table->tinyInteger('ch_pat_paysID')->change();
+            $table->smallInteger('ch_pat_paysID')->change();
         });
     }
-};
+}

--- a/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
+++ b/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('histoire', function (Blueprint $table) {
+            $table->integer('ch_his_paysID')->change();
+        });
+
+        Schema::table('patrimoine', function (Blueprint $table) {
+            $table->integer('ch_pat_paysID')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('histoire', function (Blueprint $table) {
+            $table->tinyInteger('ch_his_paysID')->change();
+        });
+
+        Schema::table('patrimoine', function (Blueprint $table) {
+            $table->tinyInteger('ch_pat_paysID')->change();
+        });
+    }
+};

--- a/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
+++ b/database/migrations/2024_02_15_220928_fix_tinyint_to_int.php
@@ -13,11 +13,6 @@ class FixTinyintToInt extends Migration
      */
     public function up()
     {
-        DB::statement('UPDATE `histoire` SET ch_his_date_fait = "0001-01-01 00:00:00"'
-            . ' WHERE ch_his_date_fait IS NULL OR ch_his_date_fait = "0000-00-00 00:00:00"');
-        DB::statement('UPDATE `histoire` SET ch_his_date_fait2 = NULL'
-            . ' WHERE ch_his_date_fait2 = "0000-00-00 00:00:00"');
-
         Schema::table('histoire', function (Blueprint $table) {
             $table->integer('ch_his_paysID')->change();
         });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,11 @@ services:
     volumes:
       - ./docker/mysql/data:/var/lib/mysql
       - ./docker/mysql/entrypoint:/docker-entrypoint-initdb.d
-    command: [mysqld,
-        --default-authentication-plugin=mysql_native_password,
-        --character-set-server=utf8mb4,
-        --collation-server=utf8mb4_unicode_ci]
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --sql-mode=IGNORE_SPACE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
     environment:
       MYSQL_ROOT_PASSWORD: root
 


### PR DESCRIPTION
Les clés étrangères de pays au format ``TINYINT(3)``, inadapté pr des ID pays, sont converties en type ``INT(11)``.

Bon, dû au bug avec les migrations (cf. #50), la requête pr les migrations à faire exécuter par un admin est décrite ici : https://github.com/Roxayl/mondegc/issues/50#issuecomment-1948205126
